### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ This sample application demonstrate how to create a desktop application using An
 
 
 
-#Install
+# Install
 --- 
 
 Install dependencies.
@@ -28,7 +28,7 @@ npm install
 ```
 
 
-#Run 
+# Run 
 ---
 
 Run your application by entering following command in your command prompt
@@ -37,7 +37,7 @@ Run your application by entering following command in your command prompt
 	gulp run
 ```
 
-#Release
+# Release
 ---
 
 You can get the release version with following command:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
